### PR TITLE
Including related sections in lists

### DIFF
--- a/lib/prepare-auto-query.js
+++ b/lib/prepare-auto-query.js
@@ -1,3 +1,5 @@
+var _ = require('lodash')
+
 module.exports = prepareAutoQuery
 
 function prepareAutoQuery(list) {
@@ -11,7 +13,8 @@ function prepareAutoQuery(list) {
   }
 
   if (Array.isArray(list.sections) && list.sections.length) {
-    q.query.section = { $in: list.sections }
+    q.query = _.extend(q.query, { $or: [ { section: { $in: list.sections } },
+                                  { relatedSections: { $in: list.sections } } ]})
   }
 
   if (Array.isArray(list.articleTypes) && list.articleTypes.length) {

--- a/test/auto-list.test.js
+++ b/test/auto-list.test.js
@@ -137,7 +137,7 @@ describe('List aggregator (for an auto list)', function () {
       })
   })
 
-  it('should return related sections', function (done) {
+  it('should return articles that have the specified section(s) as related sections', function (done) {
 
     var articles = []
       , listId

--- a/test/fields.test.js
+++ b/test/fields.test.js
@@ -70,7 +70,7 @@ describe('List aggregator fields option', function () {
           results.forEach(function (result) {
             // _id is always returned from mongo
             Object.keys(result).length.should.equal(2)
-            Object.keys(result)[0].should.equal('longTitle')
+            Object.keys(result)[1].should.equal('longTitle')
           })
           done()
         })
@@ -110,7 +110,7 @@ describe('List aggregator fields option', function () {
           results.forEach(function (result) {
             // _id is always returned from mongo
             Object.keys(result).length.should.equal(3)
-            Object.keys(result)[0].should.equal('longTitle')
+            Object.keys(result)[1].should.equal('longTitle')
           })
           done()
         })


### PR DESCRIPTION
The list aggregator now takes into account related sections. For example, if you have a list with a section of 5, the list will also contain all articles that have 5 as a related section as well as those that have 5 as their section. 