### PR TITLE
Ignore left over manual list items when processing automatic lists

### DIFF
--- a/lib/aggregator.js
+++ b/lib/aggregator.js
@@ -36,7 +36,9 @@ function createAggregator (crudService, options) {
     crudService.findPublic(q.query, q.options, function (err, unprocessedResults) {
 
       if (err) return cb(err)
-      processResults(unprocessedResults, list.items, function (error, results) {
+
+      var items = list.type === 'manual' ? list.items : null
+      processResults(unprocessedResults, items, function (error, results) {
         if (error) return cb(error)
 
         if (list.type !== 'manual') return cb(null, prepareResults(results, overrides))

--- a/test/auto-list.test.js
+++ b/test/auto-list.test.js
@@ -251,6 +251,41 @@ describe('List aggregator (for an auto list)', function () {
     )
   })
 
+  it('should ignore any specific list items', function (done) {
+
+    var listId
+      , listService = createListService()
+      , sectionService = createSectionService()
+      , articleService = createArticleService()
+
+    async.series(
+      [ publishedArticleMaker.createArticles(5, articleService, [])
+      , draftArticleMaker(articleService)
+      , function (cb) {
+          listService.create(
+            { type: 'auto'
+            , name: 'test list'
+            , order: 'recent'
+            , items: [ { itemId: 'abc123', isCustom: false } ]
+            , limit: 3
+            }
+            , function (err, res) {
+                if (err) return cb(err)
+                listId = res._id
+                cb(null)
+              })
+        }
+      ], function (err) {
+        if (err) return done(err)
+        var aggregate = createAggregator(listService, sectionService, articleService, { logger: logger })
+        aggregate(listId, null, null, mockSection, function (err, results) {
+          should.not.exist(err)
+          results.should.have.length(3)
+          done()
+        })
+      })
+  })
+
   it('should allow overriding of the prepareAutoQuery function', function (done) {
 
     var listId


### PR DESCRIPTION
Fixes an issue that we have had on a number of sites, which is quite fiddly to fix at the CMS layer. 

Instead of relying on that fix to exist, fixing it once and for all at the source.

Issue being:

Create a manual list.
Add some items.
Save list
Change list to an auto list
Set some options
Save list

List will only ever show the manual item, even though its an auto list

@bengourley would you mind taking a look and merging / publishing if happy? Will need to bump cf-dedupe-list-aggregator once published as well