### PR TITLE
Support filtering lists by article type

### DIFF
--- a/lib/prepare-auto-query.js
+++ b/lib/prepare-auto-query.js
@@ -3,10 +3,12 @@ module.exports = prepareAutoQuery
 function prepareAutoQuery (list) {
 
   var q = { query: {}, options: {}, overrides: null }
-    , properties = [ 'tags', 'sections' ]
+    , properties = [ 'tags', 'sections', 'articleTypes' ]
+    , articlePropertyMap = { articleTypes: 'type' }
 
   properties.forEach(function (p) {
-    if (Array.isArray(list[p]) && list[p].length) q.query[p] = { $in: list[p] }
+    var queryKey = articlePropertyMap[p] || p
+    if (Array.isArray(list[p]) && list[p].length) q.query[queryKey] = { $in: list[p] }
   })
 
   // TODO: enable other order options by faciliting them being passed in

--- a/test/prepare-auto-query.test.js
+++ b/test/prepare-auto-query.test.js
@@ -1,0 +1,16 @@
+var prepareAutoQuery = require('../lib/prepare-auto-query')
+  , assert = require('assert')
+
+describe('prepareAutoQuery()', function () {
+
+  it('should support articleType queries', function () {
+    var list = { articleTypes: [ 'type1', 'type2' ] }
+    assert.deepEqual(prepareAutoQuery(list),
+      { query: { type: { '$in': [ 'type1', 'type2' ] } }
+      , options: {}
+      , overrides: null
+    })
+  })
+
+})
+


### PR DESCRIPTION
This was previously supported in v1, but got removed in this refactor:
https://github.com/clocklimited/cf-list-aggregator/commit/d060ed28bbe24dd46cbfe491e8732c4d36eb94b5